### PR TITLE
Add grayscale hover effect to featured image

### DIFF
--- a/src/app/[lang]/_components/FeaturedSection.tsx
+++ b/src/app/[lang]/_components/FeaturedSection.tsx
@@ -15,7 +15,7 @@ export default async function FeaturedSection() {
         sizes="100%"
         fill
         loading='lazy'
-        className="object-contain absolute"
+        className="object-contain absolute grayscale hover:grayscale-0 transition-all duration-300"
       />
     </div>
   )


### PR DESCRIPTION
The featured image now displays in grayscale by default and transitions to full color on hover, enhancing visual interactivity.